### PR TITLE
Fix bug after help window minimising

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -213,7 +213,6 @@ _Details coming soon ..._
 ## Known issues
 
 1. **When using multiple screens**, if you move the application to a secondary screen, and later switch to using only the primary screen, the GUI will open off-screen. The remedy is to delete the `preferences.json` file created by the application before running the application again.
-2. **If you minimize the Help Window** and then run the `help` command (or use the `Help` menu, or the keyboard shortcut `F1`) again, the original Help Window will remain minimized, and no new Help Window will appear. The remedy is to manually restore the minimized Help Window.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/greynekos/greybook/ui/HelpWindow.java
+++ b/src/main/java/greynekos/greybook/ui/HelpWindow.java
@@ -82,7 +82,12 @@ public class HelpWindow extends UiPart<Stage> {
      * Focuses on the help window.
      */
     public void focus() {
+        if (getRoot().isIconified()) {
+            getRoot().setIconified(false);
+        }
+        getRoot().toFront();
         getRoot().requestFocus();
+        getRoot().centerOnScreen();
     }
 
     /**


### PR DESCRIPTION
Fixes #92 

The issue was due to the code not checking for the stage's `iconified` property, and setting that to `false`.

This PR also focuses the help window to the centre of the screen.